### PR TITLE
aws-ha-release Suspend certain processes

### DIFF
--- a/aws-ha-release/aws-ha-release.sh
+++ b/aws-ha-release/aws-ha-release.sh
@@ -152,12 +152,16 @@ do
 			exit 79
 		fi
 
-		for elb in "${asg_elbs[@]}"
+		for index in "${!asg_elbs[@]}"
 		do
-			inservice_instance_list=`elb-describe-instance-health $elb --region $region --show-long | grep InService`
+			inservice_instance_list=`elb-describe-instance-health ${asg_elbs[$index]} --region $region --show-long | grep InService`
 			inservice_instance_count=`echo "$inservice_instance_list" | wc -l`
 
-			[[ $inservice_instance_count -lt $asg_temporary_desired_capacity ]] && all_instances_inservice=0 || all_instances_inservice=1
+			if [ $index -eq 0 ]
+				then [ $inservice_instance_count -eq $asg_temporary_desired_capacity ] && all_instances_inservice=1 || all_instances_inservice=0
+			else
+				[[ ($all_instances_inservice -eq 1) && ($inservice_instance_count -eq $asg_temporary_desired_capacity) ]] && all_instances_inservice=1 || all_instances_inservice=0
+			fi
 		done
 
 		#sleeps a particular amount of time 


### PR DESCRIPTION
I noticed sometimes while running aws-ha-release.sh it would claim it failed but in fact the instances did successfully cycle. While digging into this, I realized that an alarm for scaling down the number of instances was triggering and killing an instance after the second one came up but before aws-ha-release had the chance to see that it was there.

The script, therefore, would see consistently see 1 instance even though the running instances was new and the old one was already killed.

To fix this, I decided to suspend the AutoScaling processes that aren't necessary for this script and leave the rest running; it seems to be more reliable, now.

I also added support for multiple load balancers. Each created instance must be reported as healthy from all load balancers before the script will continue (just in case each load balancer has a different health check). Resolves https://github.com/colinbjohnson/aws-missing-tools/issues/10
