### PR TITLE
update AWS environment variables

### DIFF
--- a/ec2-automate-backup/Resources/cron-primer.sh
+++ b/ec2-automate-backup/Resources/cron-primer.sh
@@ -7,11 +7,11 @@ export JAVA_HOME=/usr/lib/jvm/jre
 # export PATH=/opt/aws/bin/ is required for EC2 API Tools
 # typical system path PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/aws/bin:/home/ec2-user/bin
 export PATH=/bin:/opt/aws/bin/
-export AWS_ACCESS_KEY=<your_access_key>
-export AWS_SECRET_KEY=<your_secret_key>
+export AWS_ACCESS_KEY_ID=<your_access_key>
+export AWS_SECRET_ACCESS_KEY=<your_secret_key>
 # the environment variables below (EC2_PRIVATE_KEY and EC2_CERT) are deprecated
 # as of the release of EC2 API Tools 1.6.0.0 - it is recommended that users
 # upgrade to a version of the EC2 API Tools equal to or greater than 1.6.0.0
-# and use the environment variables AWS_ACCESS_KEY and AWS_SECRET_KEY instead.
+# and use the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY instead.
 # export EC2_PRIVATE_KEY=/path/to/your/private/key.pem
 # export EC2_CERT=/path/to/your/cert.pem


### PR DESCRIPTION
The `aws` program looks for the following environment variables to be set:

* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY `

Source: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html

I've confirmed this to work on a new EC2 instance, using the Amazon AMI (AWS CLI 1.4.2).