### PR TITLE
fix a bug introduced by aws cli change of CreateSnapshot Response #247

### DIFF
--- a/ec2-automate-backup/ec2-automate-backup-awscli.sh
+++ b/ec2-automate-backup/ec2-automate-backup-awscli.sh
@@ -43,7 +43,7 @@ get_EBS_List() {
   esac
   #creates a list of all ebs volumes that match the selection string from above
   ebs_backup_list=$(aws ec2 describe-volumes --region $region $ebs_selection_string --output text --query 'Volumes[*].VolumeId')
-  #takes the output of the previous command 
+  #takes the output of the previous command
   ebs_backup_list_result=$(echo $?)
   if [[ $ebs_backup_list_result -gt 0 ]]; then
     echo -e "An error occurred when running ec2-describe-volumes. The error returned is below:\n$ebs_backup_list_complete" 1>&2 ; exit 70
@@ -112,7 +112,7 @@ purge_EBS_Snapshots() {
   # snapshot_purge_allowed is a string containing the SnapshotIDs of snapshots
   # that contain a tag with the key value/pair PurgeAllow=true
   snapshot_purge_allowed=$(aws ec2 describe-snapshots --region $region --filters Name=tag:PurgeAllow,Values=true --output text --query 'Snapshots[*].SnapshotId')
-  
+
   for snapshot_id_evaluated in $snapshot_purge_allowed; do
     #gets the "PurgeAfterFE" date which is in UTC with UNIX Time format (or xxxxxxxxxx / %s)
     purge_after_fe=$(aws ec2 describe-snapshots --region $region --snapshot-ids $snapshot_id_evaluated --output text | grep ^TAGS.*PurgeAfterFE | cut -f 3)
@@ -208,8 +208,8 @@ for ebs_selected in $ebs_backup_list; do
   if [[ $? != 0 ]]; then
     echo -e "An error occurred when running ec2-create-snapshot. The error returned is below:\n$ec2_create_snapshot_result" 1>&2 ; exit 70
   else
-    ec2_snapshot_resource_id=$(echo "$ec2_create_snapshot_result" | cut -f 5)
-  fi  
+    ec2_snapshot_resource_id=$(echo "$ec2_create_snapshot_result" | cut -f 4)
+  fi
   create_EBS_Snapshot_Tags
 done
 


### PR DESCRIPTION
See https://github.com/boto/botocore/pull/247.

Tags key was removed from CreateSnapshot response, which means one column is removed from the result of "aws ec2 create-snapshot". To get the right snapshot id, need to use "cut -f 4"; "cut -f 5" is getting the timestamp, not snapshot id.
