### PR TITLE
Update ec2-automate-backup-awscli.sh

### DIFF
--- a/ec2-automate-backup/ec2-automate-backup-awscli.sh
+++ b/ec2-automate-backup/ec2-automate-backup-awscli.sh
@@ -208,7 +208,7 @@ for ebs_selected in $ebs_backup_list; do
   if [[ $? != 0 ]]; then
     echo -e "An error occurred when running ec2-create-snapshot. The error returned is below:\n$ec2_create_snapshot_result" 1>&2 ; exit 70
   else
-    ec2_snapshot_resource_id=$(echo "$ec2_create_snapshot_result" | cut -f 5)
+    ec2_snapshot_resource_id=$(echo "$ec2_create_snapshot_result" | cut -f 3)
   fi  
   create_EBS_Snapshot_Tags
 done


### PR DESCRIPTION
Tagging fails due to error "aws_ec2_create_tag_result='A client error (InvalidID) occurred when calling the CreateTags operation: The ID '\''2014-10-21T13:34:24.000Z'\'' is not valid'"

The command "aws ec2 create-snapshot --region $region --description $ec2_snapshot_description --volume-id $ebs_selected --output text" is giving less information, so the position of the ID has changed.
