### PR TITLE
Suggested tweaks to ec2-automate-backup-awscli

### DIFF
--- a/ec2-automate-backup/ec2-automate-backup-awscli.sh
+++ b/ec2-automate-backup/ec2-automate-backup-awscli.sh
@@ -52,14 +52,14 @@ get_EBS_List() {
 
 create_EBS_Snapshot_Tags() {
   #snapshot tags holds all tags that need to be applied to a given snapshot - by aggregating tags we ensure that ec2-create-tags is called only onece
-  snapshot_tags=""
+  snapshot_tags="Key=CreatedBy,Value=ec2-automate-backup"
   #if $name_tag_create is true then append ec2ab_${ebs_selected}_$current_date to the variable $snapshot_tags
   if $name_tag_create; then
     snapshot_tags="$snapshot_tags Key=Name,Value=ec2ab_${ebs_selected}_$current_date"
   fi
   #if $hostname_tag_create is true then append --tag InitiatingHost=$(hostname -f) to the variable $snapshot_tags
   if $hostname_tag_create; then
-    snapshot_tags="$snapshot_tags Key=InitiatingHost,Value='$(hostname -f)'"
+    snapshot_tags="$snapshot_tags Key=InitiatingHost,Value='$(hostname -s)'"
   fi
   #if $purge_after_date_fe is true, then append $purge_after_date_fe to the variable $snapshot_tags
   if [[ -n $purge_after_date_fe ]]; then


### PR DESCRIPTION
- `hostname -f` uses the hostname from /etc/hosts but this is almost always localhost. For my setup, I prefer setting the Linux hostname appropriately, which is `hostname -s` -- your preference may be different but I figured I'd suggest it.
- During disaster recovery / prevention, the original CRON job may be lost and future admins may struggle to figure out how automated backups were being created. The hostname helps with this, but also tagging with CreatedBy ec2-automate-backup will give people a term to search for, for instructions on getting things running again. Again, just a suggestion (maybe instead of this, there could just be an option to add custom tags? Or it could be added to -u ?)
- I only made these edits to the awscli version since that's the only one I'm using, if accepted they should be made to the other script too.