### PR TITLE
Migrate route53 aliases and entries with same name but different types

### DIFF
--- a/route53-migrate-zone/route53-migrate-zone.py
+++ b/route53-migrate-zone/route53-migrate-zone.py
@@ -170,7 +170,7 @@ for record in resource_record_dict:
         migrated_record_count += uncommitted_change_elements
         uncommitted_change_elements = 0
         destination_zone_record_changeset = None
-6
+
         destination_zone_record_changeset = boto.route53.record.ResourceRecordSets(destination_connection, destination_zone_id)
 
 logging.info('Summary:')


### PR DESCRIPTION
We used this to migrate all our domains to another account. Moving aliases now works out of the box with boto and comparing entry types and not just names, makes sure no valid entry leaves behind.
