### PR TITLE
Allow custom name for single snapshots

### DIFF
--- a/ec2-automate-backup/ec2-automate-backup-awscli.sh
+++ b/ec2-automate-backup/ec2-automate-backup-awscli.sh
@@ -56,6 +56,8 @@ create_EBS_Snapshot_Tags() {
   #if $name_tag_create is true then append ec2ab_${ebs_selected}_$current_date to the variable $snapshot_tags
   if $name_tag_create; then
     snapshot_tags="$snapshot_tags Key=Name,Value=ec2ab_${ebs_selected}_$current_date"
+  elif [[ $user_created_name != "" ]]; then
+    snapshot_tags="$snapshot_tags Key=Name,Value=$user_created_name"
   fi
   #if $hostname_tag_create is true then append --tag InitiatingHost=$(hostname -f) to the variable $snapshot_tags
   if $hostname_tag_create; then
@@ -147,7 +149,7 @@ user_tags=false
 purge_snapshots=false
 #handles options processing
 
-while getopts :s:c:r:v:t:k:pnhu opt; do
+while getopts :s:c:r:v:t:k:o:pnhu opt; do
   case $opt in
     s) selection_method="$OPTARG" ;;
     c) cron_primer="$OPTARG" ;;
@@ -155,6 +157,7 @@ while getopts :s:c:r:v:t:k:pnhu opt; do
     v) volumeid="$OPTARG" ;;
     t) tag="$OPTARG" ;;
     k) purge_after_input="$OPTARG" ;;
+    o) user_created_name="$OPTARG" ;;
     n) name_tag_create=true ;;
     h) hostname_tag_create=true ;;
     p) purge_snapshots=true ;;


### PR DESCRIPTION
For single snapshots, allow the name value to be overridden.

Ex: ec2-automate-backup-awscli.sh -v vol-1234abc -o Foo