### PR TITLE
Improve ec2 snapshot purge performance

### DIFF
--- a/ec2-automate-backup/ec2-automate-backup.sh
+++ b/ec2-automate-backup/ec2-automate-backup.sh
@@ -111,7 +111,7 @@ esac
 
 purge_EBS_Snapshots() {
   # Query what we need up front, then begin deleting snapshots.
-  snapshots=$(aws ec2 describe-snapshots --filters Name=tag:PurgeAllow,Values=true --output text --query 'Snapshots[*].[Tags[?Key==`PurgeAfterFE`].Value | [0], SnapshotId]' | tr '\t' ' ')
+  snapshots=$(aws ec2 describe-snapshots --region $region --filters Name=tag:PurgeAllow,Values=true --output text --query 'Snapshots[*].[Tags[?Key==`PurgeAfterFE`].Value | [0], SnapshotId]' | tr '\t' ' ')
   echo "$snapshots" | while read line; do
     snapshot_id=${line#* }
     purge_after_fe=${line% *}


### PR DESCRIPTION
This significantly reduces the time it takes to purge snapshots. For example, if you have 1000 snaphots, it takes roughly 8 minutes for this process to complete. With this change, I was able to cut it down to about 30 seconds. 

Instead of describing one instance at a time in the loop, I query for the data up front, then iterate only to delete the expired snapshot.
