### PR TITLE
Incorrect result variable echoed in ec2-automate-backup.sh

### DIFF
--- a/ec2-automate-backup/ec2-automate-backup.sh
+++ b/ec2-automate-backup/ec2-automate-backup.sh
@@ -207,7 +207,7 @@ for ebs_selected in $ebs_backup_list; do
   ec2_snapshot_description="ec2ab_${ebs_selected}_$current_date"
   ec2_snapshot_resource_id=$(aws ec2 create-snapshot --region $region --description $ec2_snapshot_description --volume-id $ebs_selected --output text --query SnapshotId 2>&1)
   if [[ $? != 0 ]]; then
-    echo -e "An error occurred when running ec2-create-snapshot. The error returned is below:\n$ec2_create_snapshot_result" 1>&2 ; exit 70
+    echo -e "An error occurred when running ec2-create-snapshot. The error returned is below:\n$ec2_snapshot_resource_id" 1>&2 ; exit 70
   fi  
   create_EBS_Snapshot_Tags
 done


### PR DESCRIPTION
Fix error output. There's no longer a variable called $ec2_create_snapshot_result