### PR TITLE
ec2-modify-ebs-volume -> Bring tags from previous volumen to new volume

### DIFF
--- a/ec2-modify-ebs-volume/ec2-modify-ebs-volume.py
+++ b/ec2-modify-ebs-volume/ec2-modify-ebs-volume.py
@@ -3,7 +3,6 @@
 # Date: 2013-11-17
 # Version 0.1
 # License Type: GNU GENERAL PUBLIC LICENSE, Version 3
-# Modified: 2016-02-24 pserrano (take tags from old volume to the new one)
 
 import argparse
 import logging
@@ -305,7 +304,7 @@ def wait_aws_event(object_in, object_type, wait_for_string):
 
 # creates ec2_connection object
 try:
-    ec2_connection = ec2.connect_to_region('eu-west-1')
+    ec2_connection = ec2.connect_to_region('us-east-1')
 except:
     logging.critical('An error occured when attempting to connect to the AWS API.')
     exit(1)


### PR DESCRIPTION
Hi,

I have modified your code (ec2-modify-ebs-volume) to implement for me a interesting feature to bring the posible current tags of the volume to the new one that will be created at the modification of the ebs volume. If you have implemented a tags to mantein periodics backups based on tags, you will wish to bring your current tags for the new volume

Regards 