### PR TITLE
Added InstanceName tag to volumes on backup

### DIFF
--- a/ec2-automate-backup/README.md
+++ b/ec2-automate-backup/README.md
@@ -17,7 +17,7 @@ the above example would provide a single backup of the EBS volumeid vol-6d6a0527
 ec2-automate-backup requires one of the following two parameters be provided:
 
 `-v <volumeid>` - the "volumeid" parameter is required to select EBS volumes for snapshot if ec2-automate-backup is run using the "volumeid" selection method - the "volumeid" selection method is the default selection method.
-    
+
 `-t <tag>` - the "tag" parameter is required if the "method" of selecting EBS volumes for snapshot is by tag (-s tag). The format for tag is key,Values=$desired_values (example: Backup,Values=true) and the correct method for running ec2-automate-backup in this manner is ec2-automate-backup -s tag -t Backup,Values=true".
 ## Optional Parameters:
 `-r <region>` - the region that contains the EBS volumes for which you wish to have a snapshot created.
@@ -35,6 +35,8 @@ ec2-automate-backup requires one of the following two parameters be provided:
 `-p` - the -p flag will purge (meaning delete) all snapshots that were created more than "purge after days" ago. ec2-automate-backup looks at two tags to determine which snapshots should be deleted - the PurgeAllow and PurgeAfter tags. The tags must be set as follows: PurgeAllow=true and PurgeAfter=YYYY-MM-DD where YYYY-MM-DD must be before the present date.
 
 `-u` - the -u flag will tag snapshots with additional data so that snapshots can be more easily located. Currently the two user tags created are Volume="ebs_volume" and Created="date." These can be easily modified in code.
+
+`-i` - the -i flag will tag with the snapshot attached instance name.
 
 # Potential Uses and Methods of Use:
 * To backup multiple EBS volumes use ec2-automate-backup as follows: `ec2-automate-backup.sh -v "vol-6d6a0527 vol-636a0112"`

--- a/ec2-automate-backup/Resources/ec2ab - IAM User Required Permissions.json
+++ b/ec2-automate-backup/Resources/ec2ab - IAM User Required Permissions.json
@@ -1,19 +1,20 @@
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Action": [
-				"ec2:DescribeVolumes",
-				"ec2:CreateSnapshot",
-				"ec2:DescribeSnapshots",
-				"ec2:DeleteSnapshot",
-				"ec2:CreateTags",
-				"ec2:DescribeTags"
-			],
-			"Effect": "Allow",
-			"Resource": [
-				"*"
-			]
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeVolumes",
+        "ec2:CreateSnapshot",
+        "ec2:DescribeSnapshots",
+        "ec2:DeleteSnapshot",
+        "ec2:CreateTags",
+        "ec2:DescribeTags",
+        "ec2:DescribeInstances"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
 }

--- a/ec2-automate-backup/ec2-automate-backup.sh
+++ b/ec2-automate-backup/ec2-automate-backup.sh
@@ -44,7 +44,7 @@ get_EBS_List() {
   esac
   #creates a list of all ebs volumes that match the selection string from above
   ebs_backup_list=$(aws ec2 describe-volumes --region $region $ebs_selection_string --output text --query 'Volumes[*].VolumeId')
-  #takes the output of the previous command 
+  #takes the output of the previous command
   ebs_backup_list_result=$(echo $?)
   if [[ $ebs_backup_list_result -gt 0 ]]; then
     echo -e "An error occurred when running ec2-describe-volumes. The error returned is below:\n$ebs_backup_list_complete" 1>&2 ; exit 70
@@ -54,6 +54,10 @@ get_EBS_List() {
 create_EBS_Snapshot_Tags() {
   #snapshot tags holds all tags that need to be applied to a given snapshot - by aggregating tags we ensure that ec2-create-tags is called only onece
   snapshot_tags="Key=CreatedBy,Value=ec2-automate-backup"
+  #if $instance_name_tag_create is true then append ec2_volume_instance_name to the variable $snapshot_tags
+  if $instance_name_tag_create; then
+    snapshot_tags="$snapshot_tags Key=InstanceName,Value=$ec2_volume_instance_name"
+  fi
   #if $name_tag_create is true then append ec2ab_${ebs_selected}_$current_date to the variable $snapshot_tags
   if $name_tag_create; then
     snapshot_tags="$snapshot_tags Key=Name,Value=ec2ab_${ebs_selected}_$current_date"
@@ -113,7 +117,7 @@ purge_EBS_Snapshots() {
   # snapshot_purge_allowed is a string containing the SnapshotIDs of snapshots
   # that contain a tag with the key value/pair PurgeAllow=true
   snapshot_purge_allowed=$(aws ec2 describe-snapshots --region $region --filters Name=tag:PurgeAllow,Values=true --output text --query 'Snapshots[*].SnapshotId')
-  
+
   for snapshot_id_evaluated in $snapshot_purge_allowed; do
     #gets the "PurgeAfterFE" date which is in UTC with UNIX Time format (or xxxxxxxxxx / %s)
     purge_after_fe=$(aws ec2 describe-snapshots --region $region --snapshot-ids $snapshot_id_evaluated --output text | grep ^TAGS.*PurgeAfterFE | cut -f 3)
@@ -149,9 +153,11 @@ hostname_tag_create=false
 user_tags=false
 #sets the Purge Snapshot feature to false - if purge_snapshots=true then snapshots will be purged
 purge_snapshots=false
+#sets the "InstanceName" tag set for a snapshot to be false
+instance_name_tag_create=false
 #handles options processing
 
-while getopts :s:c:r:v:t:k:pnhu opt; do
+while getopts :s:c:r:v:t:k:pnhui opt; do
   case $opt in
     s) selection_method="$OPTARG" ;;
     c) cron_primer="$OPTARG" ;;
@@ -163,6 +169,7 @@ while getopts :s:c:r:v:t:k:pnhu opt; do
     h) hostname_tag_create=true ;;
     p) purge_snapshots=true ;;
     u) user_tags=true ;;
+    i) instance_name_tag_create=true ;;
     *) echo "Error with Options Input. Cause of failure is most likely that an unsupported parameter was passed or a parameter was passed without a corresponding option." 1>&2 ; exit 64 ;;
   esac
 done
@@ -204,11 +211,19 @@ get_EBS_List
 
 #the loop below is called once for each volume in $ebs_backup_list - the currently selected EBS volume is passed in as "ebs_selected"
 for ebs_selected in $ebs_backup_list; do
+  if $instance_name_tag_create; then
+    #get the id of the instance the volume is attached to
+    ec2_volume_instance_id=$(aws ec2 describe-volumes --region $region --output text --volume-id $ebs_selected  --query 'Volumes[*].[Attachments[*].InstanceId]')
+    #get the name of the instance for the instance id
+    ec2_volume_instance_name=$(aws ec2 describe-instances --region $region --output text --instance-id $ec2_volume_instance_id --query 'Reservations[].Instances[].Tags[?Key==`Name`].Value')
+    #replace spaces with underscores (issue with tagging)
+    ec2_volume_instance_name=$(echo "$ec2_volume_instance_name"|sed -e 's/ /_/g')
+  fi
   ec2_snapshot_description="ec2ab_${ebs_selected}_$current_date"
   ec2_snapshot_resource_id=$(aws ec2 create-snapshot --region $region --description $ec2_snapshot_description --volume-id $ebs_selected --output text --query SnapshotId 2>&1)
   if [[ $? != 0 ]]; then
     echo -e "An error occurred when running ec2-create-snapshot. The error returned is below:\n$ec2_create_snapshot_result" 1>&2 ; exit 70
-  fi  
+  fi
   create_EBS_Snapshot_Tags
 done
 


### PR DESCRIPTION
Added the option "i" to tag volumes with the Instance Name from the
attached instance ID.

This PR was originally created by @cwturley in
colinbjohnson/aws-missing-tools/pull/74/files.  Merge conflicts
corrected, and added `--region` to `aws` calls, the latter is based off
@iiro recommendation.